### PR TITLE
Deprecate ML project

### DIFF
--- a/strategies/google-wiki-ml/README.md
+++ b/strategies/google-wiki-ml/README.md
@@ -1,0 +1,5 @@
+# This Project Has Moved
+
+This project has moved to its own repository, which can be accessed [here](https://github.com/adeet1/rqa-ml-classifier).
+
+It is no longer being maintained in this repo (Juanjo-Capital/jjcap).

--- a/strategies/google-wiki-ml/index.md
+++ b/strategies/google-wiki-ml/index.md
@@ -3,7 +3,7 @@
 [Return to main page](../../index.md)
 
 ## About
-[Project link](https://github.com/Juanjo-Capital/jjcap/tree/master/strategies/google-wiki-ml)
+[Project link](https://github.com/adeet1/rqa-ml-classifier)
 
 ## External Collaborators
 - Andrew Holpe (Richmond Quantitative Advisors)


### PR DESCRIPTION
The ML project will no longer be maintained in this repo (Juanjo-Capital/jjcap). It has moved [here](https://github.com/adeet1/rqa-ml-classifier).